### PR TITLE
Fix nextLink ordering

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -37,7 +37,7 @@ xmart4_api <- function(mart,
 
   query <- modify_query(query)
   t_q <- join_top_query(top, query)
-
+  t_q <- join_tq_skip(t_q, full_table)
   token <- check_raw_token(token, auth_type, xmart_server)
   url <- xmart_url(mart,
                    table,
@@ -87,12 +87,22 @@ join_top_query <- function(top, query) {
   paste(x, collapse = "&")
 }
 
+join_tq_skip <- function(tq, full_table) {
+  if (full_table) {
+    x <- c("$skip=0", tq)
+    x <- x[!is.null(x) & x != ""]
+    tq <- paste(x, collapse = "&")
+  }
+  tq
+}
+
 #' @noRd
 xmart4_get <- function(url, t_q, token, full_table) {
   resp <- httr::GET(httr::modify_url(url),
                     token_header(token),
                     ua,
                     query = t_q)
+  print(resp$url)
   assert_status_code(resp)
   assert_json(resp)
   parsed <- httr::content(resp,

--- a/R/get.R
+++ b/R/get.R
@@ -37,7 +37,7 @@ xmart4_api <- function(mart,
 
   query <- modify_query(query)
   t_q <- join_top_query(top, query)
-
+  t_q <- join_tq_skip(t_q, full_table)
   token <- check_raw_token(token, auth_type, xmart_server)
   url <- xmart_url(mart,
                    table,
@@ -85,6 +85,15 @@ join_top_query <- function(top, query) {
   x <- c(query, top)
   x <- x[!is.null(x)]
   paste(x, collapse = "&")
+}
+
+join_tq_skip <- function(tq, full_table) {
+  if (full_table) {
+    x <- c("$skip=0", tq)
+    x <- x[!is.null(x) & x != ""]
+    tq <- paste(x, collapse = "&")
+  }
+  tq
 }
 
 #' @noRd

--- a/R/get.R
+++ b/R/get.R
@@ -102,7 +102,6 @@ xmart4_get <- function(url, t_q, token, full_table) {
                     token_header(token),
                     ua,
                     query = t_q)
-  print(resp$url)
   assert_status_code(resp)
   assert_json(resp)
   parsed <- httr::content(resp,


### PR DESCRIPTION
Address issue of record ordering when using nextLink by explicitly setting `$skip=0` in iniital call to force the same ordering for all calls to the xMart4 API.